### PR TITLE
Fix the atlys testing symlink

### DIFF
--- a/atlys/firmware/testing
+++ b/atlys/firmware/testing
@@ -1,1 +1,0 @@
-../../archive/v0.0.0-453-g4f2aac2/atlys/hdmi2usb

--- a/atlys/firmware/v0.0.0-453-g4f2aac2
+++ b/atlys/firmware/v0.0.0-453-g4f2aac2
@@ -1,0 +1,1 @@
+../../archive/master/v0.0.0-453-g4f2aac2


### PR DESCRIPTION
The testing firmware is currently a dangling symlink. Point to the correct location.